### PR TITLE
Sitemap generator

### DIFF
--- a/lib/jsduck/app.rb
+++ b/lib/jsduck/app.rb
@@ -14,6 +14,7 @@ require 'jsduck/videos'
 require 'jsduck/examples'
 require 'jsduck/categories'
 require 'jsduck/images'
+require 'jsduck/sitemap'
 require 'jsduck/json_duck'
 require 'jsduck/lint'
 require 'jsduck/template_dir'
@@ -90,6 +91,17 @@ module JsDuck
         @videos.write(@opts.output_dir+"/videos")
         @examples.write(@opts.output_dir+"/examples")
         @images.copy(@opts.output_dir+"/images")
+      end
+
+      if @opts.seo
+
+        @sitemap = Sitemap.new({
+          :base_url => "http://docs.sencha.com/touch/2-0",
+          :categories => @categories,
+          :guides => @guides
+        })
+
+        @sitemap.write(@opts.output_dir + "/sitemap.xml")
       end
     end
 

--- a/lib/jsduck/categories.rb
+++ b/lib/jsduck/categories.rb
@@ -107,6 +107,10 @@ module JsDuck
       arr.reduce(0) {|sum, item| sum + item["classes"].length + header_size }
     end
 
+    def to_array
+      @categories
+    end
+
   end
 
 end

--- a/lib/jsduck/sitemap.rb
+++ b/lib/jsduck/sitemap.rb
@@ -1,0 +1,48 @@
+module JsDuck
+
+  class Sitemap
+
+    def initialize(opts)
+      @opts = opts
+    end
+
+    # Writes sitemap.xml to a file
+    def write(file)
+      urls = []
+
+      if @opts[:categories]
+        @opts[:categories].to_array.collect do |category|
+          category['groups'].each do |group|
+            group['classes'].each do |cls|
+              urls << "  <url><loc>#{@opts[:base_url]}/#!/api/#{cls}</loc></url>"
+            end
+          end
+        end
+      end
+
+      if @opts[:guides]
+        @opts[:guides].to_array.each do |category|
+          category['items'].each do |guide|
+            urls << "  <url><loc>#{@opts[:base_url]}/#!/guide/#{guide['name']}</loc></url>"
+          end
+        end
+      end
+
+      # @videos.to_array.each do |category|
+      #   puts category['items'].collect{|vid| vid['id'] }
+      # end
+
+      File.open(file, 'w') do |f|
+        f.write [
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+            urls,
+          '</urlset>'
+        ].flatten.join("\n")
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
I've added in this simemap.xml generator which will run with the --seo option. 

At the moment the base_url is hard coded - wanted to get your input as to weather we should convert the --seo option to a string that specifies the base URL. This could also be used in the 'rel canonical' meta tag which is currently specified in an head_html command line argument
