### PR TITLE
Using mkdir_p when creating guides folders

### DIFF
--- a/lib/jsduck/guides.rb
+++ b/lib/jsduck/guides.rb
@@ -32,7 +32,7 @@ module JsDuck
 
     # Writes all guides to given dir in JsonP format
     def write(dir)
-      FileUtils.mkdir(dir) unless File.exists?(dir)
+      FileUtils.mkdir_p(dir) unless File.exists?(dir)
       each_item {|guide| write_guide(guide, dir) }
     end
 


### PR DESCRIPTION
Use mkdir_p when creating the folders, so it should be possible to have a more complex directory structure to hold and output the guide files.
