### PR TITLE
Generate full paths for images in guides

### DIFF
--- a/lib/jsduck/guides.rb
+++ b/lib/jsduck/guides.rb
@@ -59,8 +59,7 @@ module JsDuck
 
       begin
         @formatter.doc_context = {:filename => guide_file, :linenr => 0}
-        name = File.basename(guide["url"])
-        @formatter.img_path = "guides/#{name}"
+        @formatter.img_path = "guides/#{guide["name"]}"
 
         return add_toc(guide, @formatter.format(Util::IO.read(guide_file)))
       rescue


### PR DESCRIPTION
Suppose we're using JSDuck to generate guides from the following directory structure:

```
somedir/
  guides.json
  guides/
    getting_started/
      README.md
      some-image.png
    nested/
      first_guide/
        README.md
        one.png
      second_guide/
        README.md
        one.png
```

In JSDuck's generated HTML, image tags in the Getting Started guide will point to the correct path relative to the page (e.g. `guides/guide_getting_started/some-image.png`). However, the nested guides will specify the wrong paths to images: JSDuck will write `guides/first_guide/one.png` instead of the correct `guides/guide_nested_first_guide/one.png`.

This patch fixes the issue by generating the image's path based on the full name of the guide, instead of using 'File.basename' to incorrectly crop the path.
