### PR TITLE
Mitigates a fatal `ArgumentError` when enum type is nil

### DIFF
--- a/lib/jsduck/enum.rb
+++ b/lib/jsduck/enum.rb
@@ -27,6 +27,7 @@ module JsDuck
     def infer_type(cls)
       if cls[:members].length > 0
         types = cls[:members].map {|p| p[:type] }
+        types.delete_if {|type| type.nil?}
         types.sort.uniq.join("/")
       else
         "Object"


### PR DESCRIPTION
**Error Description:**

`comparison of String with nil failed (ArgumentError)`

**Patch Description:**
- before `types` array is `sort`ed, checks that each type is non-`nil`
