### PR TITLE
Cosmetic margin fix for categories page

### DIFF
--- a/template/resources/sass/_categories.scss
+++ b/template/resources/sass/_categories.scss
@@ -28,9 +28,11 @@
       margin-left: 20px; }
     .middle-column {
       float: left;
-      width: 280px; }
+      width: 280px;
+      margin-left: 20px; }
     .right-column {
-      float: left; }
+      float: left;
+      margin-left: 20px; }
     // A list of links
     .links {
       margin-left: 1.5em;


### PR DESCRIPTION
When the browser is narrow the floated columns all align left but with different margins. They should all have the same left margin so it looks consistent at any width.
