### PR TITLE
DeprecatedTag: fix typo in message

### DIFF
--- a/lib/jsduck/tag/deprecated.rb
+++ b/lib/jsduck/tag/deprecated.rb
@@ -4,7 +4,7 @@ module JsDuck::Tag
   class Deprecated < DeprecatedTag
     def initialize
       @tagname = :deprecated
-      @msg = "This {TAGNAME} has been <strong>deprected</strong>"
+      @msg = "This {TAGNAME} has been <strong>deprecated</strong>"
       @css = <<-EOCSS
         .signature .deprecated {
           background-color: #aa0000;


### PR DESCRIPTION
Hi Rene. This commit fixes a typo in the message of the deprecated tag. Thanks!
