### PR TITLE
Locale Support for JSDuck.

### DIFF
--- a/config/locale.yml
+++ b/config/locale.yml
@@ -1,0 +1,7 @@
+# -*- encoding: utf-8 -*-
+
+ja:
+    'Returns the value of {@link #cfg-#{cfg[:name]}}.' : '{@link #cfg-#{cfg[:name]}}の値を返します。'
+    'Sets the value of {@link #cfg-#{cfg[:name]}}.'    : '{@link #cfg-#{cfg[:name]}}の値を設定します.'
+    'Fires when the {@link ##{cfg[:id]}} configuration is changed by {@link #method-#{setter_name}}.' : '{@link ##{cfg[:id]}}コンフィグの値が{@link #method-#{setter_name}}で変更された時に発火します。'
+

--- a/lib/jsduck/locale.rb
+++ b/lib/jsduck/locale.rb
@@ -1,0 +1,29 @@
+require 'yaml'
+require 'jsduck/util/singleton'
+
+module JsDuck
+
+  # Locale converter of JsDuck
+  class Locale
+    include Util::Singleton
+
+    # You should change this if change the locale.
+    @@locale = ''  # e.g.) ja
+
+    def initialize
+      # Gets locale config from locale.yml
+      config = YAML.load_file(File.expand_path(File.dirname(__FILE__)) + "/../../config/locale.yml")
+
+      # Sets config by target locale.
+      @config = config[@@locale] || Hash.new
+    end
+
+    # Returns the value of locale config.
+    # If doesn't find any value, returns key character.
+    def get(key)
+      return @config[key] || key
+    end
+
+  end
+
+end

--- a/lib/jsduck/process/accessors.rb
+++ b/lib/jsduck/process/accessors.rb
@@ -1,4 +1,5 @@
 require 'jsduck/logger'
+require 'jsduck/locale'
 
 module JsDuck
   module Process
@@ -70,10 +71,12 @@ module JsDuck
 
       def create_getter(cfg)
         name = "get" + upcase_first(cfg[:name])
+        doc  = Locale.get('Returns the value of {@link #cfg-#{cfg[:name]}}.')
+        doc  = doc.gsub(/\#\{cfg\[\:name\]\}/, cfg[:name])
         return add_shared({
             :tagname => :method,
             :name => name,
-            :doc => "Returns the value of {@link #cfg-#{cfg[:name]}}.",
+            :doc => doc,
             :params => [],
             :return => {
               :type => cfg[:type],
@@ -85,10 +88,12 @@ module JsDuck
 
       def create_setter(cfg)
         name = "set" + upcase_first(cfg[:name]);
+        doc  = Locale.get('Sets the value of {@link #cfg-#{cfg[:name]}}.')
+        doc  = doc.gsub(/\#\{cfg\[\:name\]\}/, cfg[:name])
         return add_shared({
             :tagname => :method,
             :name => name,
-            :doc => "Sets the value of {@link #cfg-#{cfg[:name]}}.",
+            :doc => doc,
             :params => [{
                 :type => cfg[:type],
                 :name => cfg[:name],
@@ -101,10 +106,12 @@ module JsDuck
       def create_event(cfg)
         name = cfg[:name].downcase + "change"
         setter_name = "set" + upcase_first(cfg[:name]);
+        doc  = Locale.get('Fires when the {@link ##{cfg[:id]}} configuration is changed by {@link #method-#{setter_name}}.')
+        doc  = doc.gsub(/\#\{cfg\[\:id\]\}/, cfg[:id]).gsub(/\#\{setter_name\}/, setter_name)
         return add_shared({
             :tagname => :event,
             :name => name,
-            :doc => "Fires when the {@link ##{cfg[:id]}} configuration is changed by {@link #method-#{setter_name}}.",
+            :doc => doc,
             :params => [
               {
                 :name => "this",


### PR DESCRIPTION
Hi! I want to use JSDuck in Japanese but some description was hard coded in English.. So I added some changes to convert hard coded characters to config value. 

I created a new directory `config` at project root and put locale.yml file. It defines mapping that hard coded characters and local characters. 

If you have a good idea to solve this problem, I want to hear your opinion.

Cheers :-D

===
- Add Locale class
- Add config/locale.yml
- Update process/accessors.rb