### PR TITLE
index-template.html seems haven't worked correctly

### DIFF
--- a/lib/jsduck/web/index_html.rb
+++ b/lib/jsduck/web/index_html.rb
@@ -61,6 +61,13 @@ module JsDuck
         categories = @assets.categories.to_html
         guides = @assets.guides.to_html
 
+        # Updates hash fragment to `_escaped_fragment_=`
+        [categories, guides].each do |html|
+          html.gsub!(/\#\!/) do |key|
+            '?_escaped_fragment_='
+          end
+        end
+
         write_template(in_file, out_file, {
           "{title}" => @opts.title,
           "{header}" => header,


### PR DESCRIPTION
I used `--seo` option to enable indexing by Google. It generates index-template.html for crawler, but its links doesn't work fine.

You can check it on the index page of Sencha docs.

http://docs.sencha.com/extjs/4.2.2/?_escaped_fragment_

For example, one of the links are followings,

http://docs.sencha.com/extjs/4.2.2/?_escaped_fragment_#!/api/Ext.Base

Links should use `=` instead of `#!`? It works fine if I change it so.

That's why I've fixed it. Could you review this?

![index-template](https://cloud.githubusercontent.com/assets/321647/2578797/750faa22-b997-11e3-9f50-730d1c6fb2d7.png)
