### PR TITLE
Support for --no-private command line option.

### DIFF
--- a/lib/jsduck/batch_processor.rb
+++ b/lib/jsduck/batch_processor.rb
@@ -67,6 +67,8 @@ module JsDuck
 
     # Do all kinds of post-processing on Relations object.
     def post_process(relations, opts)
+      remove_private relations unless opts.private
+
       Process::CircularDeps.new(relations).process_all!
       Process::InheritDoc.new(relations).process_all!
       Process::Versions.new(relations, opts).process_all!
@@ -76,6 +78,14 @@ module JsDuck
       Process::Lint.new(relations).process_all!
       Process::NoDoc.new(relations).process_all!
       relations
+    end
+
+    # Remove classes and members marked as private
+    def remove_private(relations)
+      relations.classes.reject! { |cls| cls.internal_doc[:private] }
+      relations.classes.each do |cls|
+        cls.internal_doc[:members].reject! { |member| member[:private] }
+      end
     end
 
   end

--- a/lib/jsduck/options/parser.rb
+++ b/lib/jsduck/options/parser.rb
@@ -332,6 +332,14 @@ module JsDuck
           @opts.source = on
         end
 
+        attribute :private, true
+        option('--[no-]private',
+          "Enables output of private classes and members. (ON)",
+          "",
+          "Enabled by default.") do |on|
+          @opts.private = on
+        end
+
         attribute :images, []
         option('--images=PATH1,PATH2', Array,
           "Paths for images referenced by {@img} tag.",


### PR DESCRIPTION
The new command line option excludes all classes and members marked with @private from generated output.

Implement #541