### PR TITLE
Specify sass version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - gem install rspec
   - gem install rake
   - gem install dimensions
-  - gem install sass
+  - gem install sass --version '~> 3.2.0'


### PR DESCRIPTION
Hi!

I've found that `sass 3.3.x` breaks some of the css related specs of jsduck.
Although the build on ruby 1.8.7 is still failing, this change fixes the builds on ruby 1.9.3 and 2.0.0 on Travis-ci.
( https://travis-ci.org/kt3k/jsduck/builds/25392475 )

Thanks!
