### PR TITLE
fix ruby versions and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,5 @@
-language: ruby
+sudo: false
 rvm:
-  - "1.8.7"
   - "1.9.3"
   - "2.0.0"
-install:
-  - gem install rdiscount
-  - gem install json
-  - gem install parallel
-  - gem install rkelly-remix
-  - gem install rspec
-  - gem install rake
-  - gem install dimensions
-  - gem install sass --version '~> 3.2.0'
+  - "2.1.5"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/jsduck.gemspec
+++ b/jsduck.gemspec
@@ -1,9 +1,11 @@
+require File.join(File.dirname(__FILE__), 'lib/jsduck/version')
+
 Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.8"
   s.required_rubygems_version = ">= 1.3.5"
 
   s.name = 'jsduck'
-  s.version = `./bin/jsduck --version`.sub(/\AJSDuck ([\w.]+).*\z/m, "\\1")
+  s.version = JsDuck::VERSION
   s.date = Time.new.strftime('%Y-%m-%d')
   s.summary = "Simple JavaScript Duckumentation generator"
   s.description = "Documentation generator for Sencha JS frameworks"


### PR DESCRIPTION
refs #598 - I couldn't get Ruby 1.8 to work. SLES 11 and RHEL 6 use Ruby 1.8 and are still supported, so this is not ideal...