### PR TITLE
Expand symbolic linked folders

### DIFF
--- a/lib/jsduck/options/input_files.rb
+++ b/lib/jsduck/options/input_files.rb
@@ -33,7 +33,7 @@ module JsDuck
 
         if File.exists?(fname)
           if File.directory?(fname)
-            Dir[fname+"/**/*.{js,scss}"].each {|f| files << f }
+            Dir.glob([fname+"/**{,/*/**}/*.{js,scss}"],0).each {|f| files << f }
           elsif fname =~ /\.jsb3$/
             Options::Jsb.read(fname).each {|fn| read_filenames(fn) }
           else


### PR DESCRIPTION
When expanding folders, also expand symbolic links.
Fixes #631.