### PR TITLE
Fix base URL if window.location contains index.php

### DIFF
--- a/template/app/controller/Content.js
+++ b/template/app/controller/Content.js
@@ -37,6 +37,6 @@ Ext.define('Docs.controller.Content', {
      * @return {String} URL
      */
     getBaseUrl: function() {
-        return document.location.href.replace(/\/?(index.html|template.html)?(\?[^#]*)?#.*/, "");
+        return document.location.href.replace(/\/?(index.php|template.html)?(\?[^#]*)?#.*/, "");
     }
 });


### PR DESCRIPTION
I assume it was forgotten that this replace part should be renamed, after it was decided that index.html shall become index.php.

Currently I have to use a pretty ugly hack with the --body-html config

```
var getBaseUrl = Docs.controller.Content.prototype.getBaseUrl;
Docs.controller.Content.prototype.getBaseUrl = function(){
    var r = getBaseUrl.apply(this,arguments);
    r = r.replace('/index.php','');
    return r;
}
```