### PR TITLE
docs: Fix simple typo, firering -> firing

### DIFF
--- a/template/app/view/SimpleSelectBehavior.js
+++ b/template/app/view/SimpleSelectBehavior.js
@@ -30,7 +30,7 @@ Ext.define('Docs.view.SimpleSelectBehavior', {
 
     /**
      * Creates a wrapper around selection model.
-     * @param {Ext.Component} selModel A component firering "select"
+     * @param {Ext.Component} selModel A component firing "select"
      * and "deselect" events.
      * @param {Object} listeners The listeners config for Observable.
      */

--- a/template/app/view/tests/BatchRunner.js
+++ b/template/app/view/tests/BatchRunner.js
@@ -2,7 +2,7 @@
  * Component for running multiple tests in batch mode.
  *
  * Calling the #run method with bunch of Docs.model.Test records will
- * start the runner, firering #start event.  After the completion of
+ * start the runner, firing #start event.  After the completion of
  * every test the #statuschange event is fired.  Finally #finish will
  * fire when all tests are done.
  */


### PR DESCRIPTION
There is a small typo in template/app/view/SimpleSelectBehavior.js, template/app/view/tests/BatchRunner.js.

Should read `firing` rather than `firering`.

